### PR TITLE
fixed compilation errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,6 @@
 obj-m+=nct5104d_gpio.o
 
 all:
-        make -C /lib/modules/$(shell uname -r)/build/ M=$(PWD) modules
+	make -C /lib/modules/$(shell uname -r)/build/ M=$(PWD) modules
 clean:
-        make -C /lib/modules/$(shell uname -r)/build/ M=$(PWD) clean
-
-
+	make -C /lib/modules/$(shell uname -r)/build/ M=$(PWD) clean

--- a/nct5104d_gpio.c
+++ b/nct5104d_gpio.c
@@ -401,6 +401,7 @@ static int nct5104d_drv_probe(struct platform_device *pdev){
 	static int err;
 	u16 devid;
 	u8 gpio_en;
+	struct platform_data_nct5104d *pdata = (struct platform_data_nct5104d *)pdev->dev.platform_data;
 
 	err = nct5104d_efm_enable();
 	if (err)

--- a/nct5104dpin/Makefile
+++ b/nct5104dpin/Makefile
@@ -3,11 +3,11 @@ src = $(wildcard *.c)
 PREFIX = /usr/local/bin
 
 nct5104dpin: $(src)
-        gcc -Wall -o $@ $^
+	gcc -Wall -o $@ $^
 
 clean:
-        rm -f $(obj) nct5104dpin
+	rm -f $(obj) nct5104dpin
 
 install: nct5104dpin
-        mkdir -p $(PREFIX)
-        cp $< $(PREFIX)/nct5104dpin
+	mkdir -p $(PREFIX)
+	cp $< $(PREFIX)/nct5104dpin

--- a/nct5104dreg/Makefile
+++ b/nct5104dreg/Makefile
@@ -3,11 +3,11 @@ src = $(wildcard *.c)
 PREFIX = /usr/local/bin
 
 nct5104dreg: $(src)
-        gcc -Wall -o $@ $^
+	gcc -Wall -o $@ $^
 
 clean:
-        rm -f $(obj) nct5104dreg
+	rm -f $(obj) nct5104dreg
 
 install: nct5104dreg
-        mkdir -p $(PREFIX)
-        cp $< $(PREFIX)/nct5104dreg
+	mkdir -p $(PREFIX)
+	cp $< $(PREFIX)/nct5104dreg


### PR DESCRIPTION
pdata is undeclared in nct5104d_drv_probe()
spaces in Makefiles instead of tabs
